### PR TITLE
PostgreSQL16 finally removed postmaster

### DIFF
--- a/opensuseleap15.5/files/start_postgresql.sh
+++ b/opensuseleap15.5/files/start_postgresql.sh
@@ -37,4 +37,4 @@ fi
 ${PG_PATH}/pg_ctl -w stop -D ${DB_PATH}/data
 
 echo "Starting PostgreSQL ${PG_VER}..."
-${PG_PATH}/postmaster -D ${DB_PATH}/data >> ${DB_PATH}/pgstartup.log 2>&1
+${PG_PATH}/postgres -D ${DB_PATH}/data >> ${DB_PATH}/pgstartup.log 2>&1

--- a/rockylinux8/files/start_postgresql.sh
+++ b/rockylinux8/files/start_postgresql.sh
@@ -37,4 +37,4 @@ fi
 ${PG_PATH}/pg_ctl -w stop -D ${DB_PATH}/data
 
 echo "Starting PostgreSQL ${PG_VER}..."
-${PG_PATH}/postmaster -D ${DB_PATH}/data >> ${DB_PATH}/pgstartup.log 2>&1
+${PG_PATH}/postgres -D ${DB_PATH}/data >> ${DB_PATH}/pgstartup.log 2>&1

--- a/ubuntu20.04/files/start_postgresql.sh
+++ b/ubuntu20.04/files/start_postgresql.sh
@@ -38,4 +38,4 @@ fi
 ${PG_PATH}/pg_ctl -w stop -D ${DB_PATH} -o "-c config_file=${ETC_PATH}/postgresql.conf"
 
 echo "Starting PostgreSQL ${PG_VER}..."
-${PG_PATH}/postmaster -D ${DB_PATH} --config_file=${ETC_PATH}/postgresql.conf >> /var/log/postgresql/postgresql-${PG_VER}-main.log 2>&1
+${PG_PATH}/postgres -D ${DB_PATH} --config_file=${ETC_PATH}/postgresql.conf >> /var/log/postgresql/postgresql-${PG_VER}-main.log 2>&1


### PR DESCRIPTION
https://postgrespro.com/blog/pgsql/5969981#commit_81266442

However it seems at least openSUSE Leap 15.5 does not contain the symlink, `postmaster`.

So considering we now only support >= 12, it should be safe to change all distributions where we are adding support for PostgreSQL 16.