### PR TITLE
Replace PostgreSQL 18-testing with 18 (stable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Run:
 
 # Running the images
 
-Tu run, for example PostgreSQL 15 under Rocky Linux 8:
+Tu run, for example PostgreSQL 18 under Rocky Linux 8:
 
 ```
-docker run -t --name test -e "DB_NAME=mydbname" -e "DB_PASS=mydbpassword" juliogonzalez/rockylinux8-postgresql15
+docker run -t --name test -e "DB_NAME=mydbname" -e "DB_PASS=mydbpassword" juliogonzalez/rockylinux8-postgresql:18
 ```
 
 Use *-e "DB_NAME=mydbname"* if you want to create a database when the container is created

--- a/manage_images
+++ b/manage_images
@@ -8,7 +8,7 @@ SCRIPT=$(basename ${0})
 
 # Supported distributions and PostgreSQL versions
 SUPPORTEDDISTROS="rockylinux8 ubuntu24.04 opensuseleap15.6"
-SUPPORTEDPGVERS="13 14 15 16 17 18-testing"
+SUPPORTEDPGVERS="13 14 15 16 17 18"
 
 # Ignored combinations, will exit without errors so the CI does not fail
 IGNOREDCOMBINATIONS=""

--- a/opensuseleap15.6/files/postgresql.repo
+++ b/opensuseleap15.6/files/postgresql.repo
@@ -1,8 +1,8 @@
 [pgdg-<!POSTGRESQL_VER!>]
-name=PostgreSQL <!POSTGRESQL_VER!> SLES $releasever - $basearch
+name=PostgreSQL <!POSTGRESQL_VER!> SLES 15 - $basearch
 enabled=1
 autorefresh=1
-baseurl=https://download.postgresql.org/pub/repos/zypp/<!POSTGRESQL_VER!>/suse/sles-$releasever-$basearch
+baseurl=https://download.postgresql.org/pub/repos/zypp/<!POSTGRESQL_VER!>/suse/sles-15-$basearch
 type=rpm-md
 gpgcheck=1
 keeppackages=0


### PR DESCRIPTION
Includes a small change for the openSUSE Leap 15.6 repository, as there's no repository specific for `15.6`:

https://download.postgresql.org/pub/repos/zypp/testing/18/suse/

However, the one for `15` (https://download.postgresql.org/pub/repos/zypp/18/suse/sles-15-x86_64/) seems to have exactly the same binaries, and looks to work just fine (also seems to be the same used for SUSE Linux Enterprise 15 SP7 (https://download.postgresql.org/pub/repos/zypp/18/suse/sles-15.7-x86_64/)